### PR TITLE
set it to latest lts release or similar as keeping up with node relea…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "node"
-  - "6"
+  - "lts/*"
 
 before_install:
   - export CHROME_BIN=chromium-browser


### PR DESCRIPTION
Travis.yml node version is now being set to latest LTS release as compared to setting it to latest node release so far. 

Latest node release is a bit too fast and does not reflect what we have in our local workarea.

More details on the syntax at: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/ . 