### PR TITLE
docs: notes for future contribution and formatting commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+We use commitlint to help maintain commits better. 
+
+More details at:
+http://marionebl.github.io/commitlint .
+
+
+## Commit types
+
+Commit types should be one of the following: 
+
+[build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] 


### PR DESCRIPTION
Add notes about various types for handy reference before commiting ( as enforced by commitlint ) 