### PR TITLE
style: The name of the class DragScroll should end with the suffix Directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 1.7.0
 
-Issue #103 - style: The name of the class DragScroll should end with the suffix Directive 
+Issue #103 - style: The name of the class DragScroll should end with the suffix Directive
+
+ ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: The directive attribute changes from drag-scroll to dragScroll`
 
 #### 1.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 Issue #103 - style: The name of the class DragScroll should end with the suffix Directive
 
- ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: The directive attribute changes from drag-scroll to dragScroll`
-
+ 1. ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: The directive attribute changes from drag-scroll to dragScroll`
+ 1. ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: DragScroll  renamed to DragScrollDirective`
 #### 1.6.3
 
 Issue #99 - fix stepped scrolling issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.7.0
+
+Issue #103 - style: The name of the class DragScroll should end with the suffix Directive 
+
 #### 1.6.3
 
 Issue #99 - fix stepped scrolling issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Issue #103 - style: The name of the class DragScroll should end with the suffix 
 
  1. ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: The directive attribute changes from drag-scroll to dragScroll`
  1. ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: DragScroll  renamed to DragScrollDirective`
+
 #### 1.6.3
 
 Issue #99 - fix stepped scrolling issue

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ___
   `
 })
 class Sample {
-  @ViewChild('nav', {read: DragScroll}) ds: DragScroll;
+  @ViewChild('nav', {read: DragScrollDirective}) ds: DragScrollDirective;
   
   moveLeft() {
     this.ds.moveLeft();
@@ -114,14 +114,14 @@ constructor(
 ) {}
 dragScrollDom: any;
 dragScrollRef: ElementRef;
-dragScroll: DragScroll;
+dragScroll: DragScrollDirective;
 
 ngAfterViewInit() {
   // attach to .nav-tabs element
   this.dragScrollDom = this.element.nativeElement.querySelector('.nav-tabs');
   this.dragScrollRef = new ElementRef(this.dragScrollDom );
 
-  this.dragScroll = new DragScroll(this.dragScrollRef, this.renderer, this.cdr);
+  this.dragScroll = new DragScrollDirective(this.dragScrollRef, this.renderer, this.cdr);
   this.dragScroll.attach({
     disabled: false,
     scrollbarHidden: true,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add the `drag-scroll` attribute to a scrollable element:
 @Component({
   selector: 'sample',
   template:`
-  <div drag-scroll>
+  <div dragScroll>
     Big text goes here...
   </div>
   `
@@ -82,7 +82,7 @@ ___
 @Component({
   selector: 'sample',
   template:`
-  <div drag-scroll #nav>
+  <div dragScroll #nav>
     Big text goes here...
   </div>
   <button (click)="moveLeft()">Left</button>

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-Address the following Lint issues:
-
-1. ERROR: /home/travis/build/bfwg/ngx-drag-scroll/src/ngx-drag-scroll.ts[18, 13]: The selector of the directive "DragScroll" should be named camelCase (https://angular.io/styleguide#style-02-06)
-
-For now - the 1 lint error is disabled by changing tsconfig.json accordingly.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 Address the following Lint issues:
 
 1. ERROR: /home/travis/build/bfwg/ngx-drag-scroll/src/ngx-drag-scroll.ts[18, 13]: The selector of the directive "DragScroll" should be named camelCase (https://angular.io/styleguide#style-02-06)
-1. ERROR: /home/travis/build/bfwg/ngx-drag-scroll/src/ngx-drag-scroll.ts[20, 14]: The name of the class DragScroll should end with the suffix Directive (https://angular.io/styleguide#style-02-03)
 
-For now - these 2 lint errors are disabled by changing tsconfig.json accordingly. 
+For now - the 1 lint error is disabled by changing tsconfig.json accordingly.

--- a/demo/app/home/home.component.html
+++ b/demo/app/home/home.component.html
@@ -2,7 +2,7 @@
   <p class="title">DRAG AND SCROLL!</p>
   <div class="demo-border">
     <div class="demo-one"
-      drag-scroll
+      dragScroll
       drag-scroll-y-disabled="true"
       scrollbar-hidden="true"
       (reachesLeftBound)="leftBoundStat($event)"
@@ -27,7 +27,7 @@
   </div>
   <div class="demo-border">
     <div class="demo-two"
-        drag-scroll [scrollbar-hidden]="hideScrollbar"
+        dragScroll [scrollbar-hidden]="hideScrollbar"
         [drag-scroll-disabled]="disabled"
         [drag-scroll-x-disabled]="xDisabled"
         [drag-scroll-y-disabled]="yDisabled"

--- a/demo/app/home/home.component.ts
+++ b/demo/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ElementRef, Renderer2, ViewChild } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material';
-import { DragScroll } from '../../../src/ngx-drag-scroll';
+import { DragScrollDirective } from '../../../src/ngx-drag-scroll';
 
 @Component({
   selector: 'app-home',
@@ -33,9 +33,9 @@ export class HomeComponent implements OnInit {
 
   dragScrollDom: any;
   dragScrollRef: ElementRef;
-  dragScroll: DragScroll;
+  dragScroll: DragScrollDirective;
 
-  @ViewChild('nav', {read: DragScroll}) ds: DragScroll;
+  @ViewChild('nav', {read: DragScrollDirective}) ds: DragScrollDirective;
 
   constructor(
     matIconRegistry: MatIconRegistry,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Lightweight drag to scroll directive for Angular",
   "contributors": [
     {

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -4,7 +4,7 @@ import {
   Renderer2,
   ElementRef
 } from '@angular/core';
-import { DragScroll } from './ngx-drag-scroll';
+import { DragScrollDirective } from './ngx-drag-scroll';
 
 import {
   By
@@ -23,11 +23,11 @@ import {
 class TestComponent {
 }
 
-describe('Directive: DragScroll', () => {
+describe('Directive: DragScrollDirective', () => {
   const scrollbarWidth = '15px';
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TestComponent, DragScroll]
+      declarations: [TestComponent, DragScrollDirective]
     });
   });
 
@@ -41,7 +41,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
 
 
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
@@ -68,7 +68,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
 
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -100}));
@@ -96,7 +96,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
 
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -100}));
@@ -124,7 +124,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
 
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -100}));
@@ -151,7 +151,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
       expect(compiled.nativeElement.style.width).toBe('100%');
       expect(compiled.nativeElement.style.height).toBe(`calc(100% + ${scrollbarWidth})`);
     });
@@ -166,7 +166,7 @@ describe('Directive: DragScroll', () => {
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
       expect(compiled.nativeElement.style.width).toBe(`calc(100% + ${scrollbarWidth})`);
       expect(compiled.nativeElement.style.height).toBe('100%');
     });
@@ -182,7 +182,7 @@ describe('Directive: DragScroll', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
       expect(compiled.nativeElement.style.width).toBe(`calc(100% + ${scrollbarWidth})`);
       expect(compiled.nativeElement.style.height).toBe(`calc(100% + ${scrollbarWidth})`);
     });
@@ -198,7 +198,7 @@ describe('Directive: DragScroll', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      const compiled = fixture.debugElement.query(By.directive(DragScroll));
+      const compiled = fixture.debugElement.query(By.directive(DragScrollDirective));
       expect(compiled.nativeElement.style.width).toBe('50px');
       expect(compiled.nativeElement.style.height).toBe('50px');
     });

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -33,7 +33,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should drag to scroll horizontally and vertically', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll>
+      template: `<div style="width: 50px; height: 50px;" dragScroll>
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -60,7 +60,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should disable drag and scroll horizontally and vertically', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll drag-scroll-disabled="true">
+      template: `<div style="width: 50px; height: 50px;" dragScroll drag-scroll-disabled="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -88,7 +88,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should disable drag and scroll horizontally', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll drag-scroll-x-disabled="true">
+      template: `<div style="width: 50px; height: 50px;" dragScroll drag-scroll-x-disabled="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -116,7 +116,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should disable drag and scroll horizontally', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll drag-scroll-y-disabled="true">
+      template: `<div style="width: 50px; height: 50px;" dragScroll drag-scroll-y-disabled="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -144,7 +144,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should only hide horizontal scroll bar', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 350px;" drag-scroll scrollbar-hidden="true">
+      template: `<div style="width: 50px; height: 350px;" dragScroll scrollbar-hidden="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -159,7 +159,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should only hide vertical scroll bar', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 350px; height: 50px;" drag-scroll scrollbar-hidden="true">
+      template: `<div style="width: 350px; height: 50px;" dragScroll scrollbar-hidden="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -174,7 +174,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should hide all scroll bars', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll scrollbar-hidden="true">
+      template: `<div style="width: 50px; height: 50px;" dragScroll scrollbar-hidden="true">
                   <div style="width: 300px; height: 300px;"></div>
                 </div>`
     }});
@@ -190,7 +190,7 @@ describe('Directive: DragScrollDirective', () => {
 
   it('should not trying to hide the scrollbar when there are nothing to hide', async(() => {
     TestBed.overrideComponent(TestComponent, {set: {
-      template: `<div style="width: 50px; height: 50px;" drag-scroll>
+      template: `<div style="width: 50px; height: 50px;" dragScroll>
                   <div style="width: 49px; height: 49px;"></div>
                 </div>`
     }});

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -15,7 +15,7 @@ import {
 import { DragScrollOption } from './interface/drag-scroll-option';
 
 @Directive({
-  selector: '[drag-scroll]'
+  selector: '[dragScroll]'
 })
 export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoCheck {
 

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -17,7 +17,7 @@ import { DragScrollOption } from './interface/drag-scroll-option';
 @Directive({
   selector: '[drag-scroll]'
 })
-export class DragScroll implements OnDestroy, OnInit, OnChanges, DoCheck {
+export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoCheck {
 
   @Output() reachesLeftBound = new EventEmitter<boolean>();
 
@@ -524,7 +524,7 @@ export class DragScroll implements OnDestroy, OnInit, OnChanges, DoCheck {
 }
 
 @NgModule({
-  exports: [DragScroll],
-  declarations: [DragScroll]
+  exports: [DragScrollDirective],
+  declarations: [DragScrollDirective]
 })
 export class DragScrollModule { }

--- a/tslint.json
+++ b/tslint.json
@@ -132,6 +132,7 @@
     "no-output-rename": true,
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
-    "component-class-suffix": true
+    "component-class-suffix": true,
+    "directive-class-suffix": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -118,6 +118,12 @@
       "check-separator",
       "check-type"
     ],
+    "directive-selector": [
+      true,
+      "attribute",
+      "",
+      "camelCase"
+    ],
     "component-selector": [
       true,
       "element",


### PR DESCRIPTION
Fix the following tslint warning.
```console
1. ERROR: /home/travis/build/bfwg/ngx-drag-scroll/src/ngx-drag-scroll.ts[20, 14]: The name of the class DragScroll should end with the suffix Directive (https://angular.io/styleguide#style-02-03)
```

More details at - https://angular.io/styleguide#style-02-03

![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: DragScroll  renamed to DragScrollDirective`
```console
1. ERROR: /home/travis/build/bfwg/ngx-drag-scroll/src/ngx-drag-scroll.ts[18, 13]: The selector of the directive "DragScroll" should be named camelCase (https://angular.io/styleguide#style-02-06)
```
More details at - https://angular.io/styleguide#style-02-06 

![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `Important: The directive attribute changes from drag-scroll to dragScroll`

