### PR TITLE
fix: firefox default to drag and drop for images bug

### DIFF
--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -406,6 +406,11 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
     this.markElDimension();
 
     this.renderer.setAttribute(this.el.nativeElement, 'drag-scroll', 'true');
+
+    // prevent Firefox from dragging images
+    document.addEventListener('dragstart', function (e) {
+      e.preventDefault();
+    });
   }
 
   ngDoCheck() {


### PR DESCRIPTION
Fixed bug that caused Firefox to default to drag-and-drop mode when images are click and dragged. Bug originally logged [here](https://github.com/bfwg/ngx-drag-scroll/issues/125).

This was due to browser's default behavior and was fixed by calling `preventDefault();` on the event object of the 'dragstart' event. See MDN reference [here](https://developer.mozilla.org/en-US/docs/Web/Events/dragstart).

I've tested this on the following browsers on Windows 10 (64-bit) without issues:

- Firefox Quantum 59.0.2 (64-bit)
- Google Chrome 65.0.3325.181 (64-bit)
- Internet Explorer 11.309.16299.0
- Microsoft Edge 41.16299.248.0