### PR TITLE
fix: onMouseUp stops all propagation when selecting text

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+* **I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => Please do not submit support request here, see note at the top of this template.
+
+
+* **Do you want to request a *feature* or report a *bug*?**
+
+
+
+* **What is the current behavior?**
+
+
+
+* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem**  you can use the demo site as an example or via https://plnkr.co
+
+
+* **What is the expected behavior?**
+
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+
+
+* **Please tell us about your environment:**
+  
+  - Version: 1.0.0
+  - Browser: [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ]
+
+
+* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,23 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our guidelines
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+* **What is the current behavior?** (You can also link to an open issue here)
+
+
+
+* **What is the new behavior (if this is a feature change)?**
+
+
+
+* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+
+* **Other information**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 1.7.7
+
+Issue #129 - onMouseUp stops all propagation when selecting text
+Add Github templates
+
 #### 1.7.6
 
 Issue #124 - fix npm install module not found issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 1.7.7
 
-Issue #129 - onMouseUp stops all propagation when selecting text
+Issue #129 - fix onMouseUp stops all propagation when selecting text
+Issue #125 - fix Drag-scroll not working on Firefox Quantum
 Add Github templates
 
 #### 1.7.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Lightweight drag to scroll directive for Angular",
   "contributors": [
     {

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -476,7 +476,6 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
   }
 
   onMouseUp(e: MouseEvent) {
-    e.preventDefault();
     if (this.isPressed) {
       this.isPressed = false;
       if (!this.snapDisabled) {
@@ -485,7 +484,6 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
         this.locateCurrentIndex();
       }
     }
-    return false;
   }
 
   /*


### PR DESCRIPTION
## Detail

- Fix #129 
- Add github templates.