### PR TITLE
feat: snap-offset to optionally show portion of previous elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ That's it! Now you can scroll it by dragging.
 | drag-scroll-y-disabled | @Input  | Whether vertically dragging and scrolling events is disabled.                 | false |
 | drag-disabled          | @Input  | Whether draging is disabled.                                                  | false |
 | snap-disabled          | @Input  | Whether snapping is disabled.                                                 | false |
+| snap-offset            | @Input  | Pixels of previous element to show on snap or moving left and right.          |   0   |
 | reachesLeftBound       | @Output | Whether reaching the left carousel bound.                                     |  n/a  |
 | reachesRightBound      | @Output | Whether reaching the right carousel bound.                                    |  n/a  |
 

--- a/demo/app/home/home.component.html
+++ b/demo/app/home/home.component.html
@@ -86,8 +86,44 @@
             <p class="docs-api-property-name"> drag-disabled </p>
             <code class="docs-api-property-type"></code>
           </td>
-          <td class="docs-api-property-description"> Disable drag event. </td>
+          <td class="docs-api-property-description"> Whether draging is disabled.</td>
           <td class="docs-api-property-description">false</td>
+        </tr>
+        <tr class="docs-api-properties-row">
+          <td class="docs-api-properties-name-cell">
+            <div class="docs-api-input-marker"> @Input()</div>
+            <p class="docs-api-property-name"> snap-disabled </p>
+            <code class="docs-api-property-type"></code>
+          </td>
+          <td class="docs-api-property-description"> Whether snapping is disabled.</td>
+          <td class="docs-api-property-description">false</td>
+        </tr>
+        <tr class="docs-api-properties-row">
+          <td class="docs-api-properties-name-cell">
+            <div class="docs-api-input-marker"> @Input()</div>
+            <p class="docs-api-property-name"> snap-offset </p>
+            <code class="docs-api-property-type"></code>
+          </td>
+          <td class="docs-api-property-description"> Pixels of previous element to show on snap or moving left and right. </td>
+          <td class="docs-api-property-description">0</td>
+        </tr>
+        <tr class="docs-api-properties-row">
+          <td class="docs-api-properties-name-cell">
+            <div class="docs-api-input-marker"> @Output()</div>
+            <p class="docs-api-property-name"> reachesLeftBound </p>
+            <code class="docs-api-property-type"></code>
+          </td>
+          <td class="docs-api-property-description"> Whether reaching the left carousel bound. </td>
+          <td class="docs-api-property-description">n/a</td>
+        </tr>
+        <tr class="docs-api-properties-row">
+          <td class="docs-api-properties-name-cell">
+            <div class="docs-api-input-marker"> @Output()</div>
+            <p class="docs-api-property-name"> reachesRightBound </p>
+            <code class="docs-api-property-type"></code>
+          </td>
+          <td class="docs-api-property-description"> Whether reaching the right carousel bound. </td>
+          <td class="docs-api-property-description">n/a</td>
         </tr>
       </tbody>
     </table>

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -30,6 +30,8 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
   private _dragDisabled: boolean;
 
   private _snapDisabled: boolean;
+
+  private _snapOffset = 0;
   /**
    * Is the user currently pressing the element
    */
@@ -207,7 +209,7 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
     const self = this;
     self.isAnimating = true;
     const start = element.scrollLeft,
-      change = to - start,
+      change = to - start - this.snapOffset,
       increment = 20;
     let currentTime = 0;
 
@@ -350,6 +352,10 @@ export class DragScrollDirective implements OnDestroy, OnInit, OnChanges, DoChec
   @Input('snap-disabled')
   get snapDisabled() { return this._snapDisabled; }
   set snapDisabled(value: boolean) { this._snapDisabled = value; }
+
+  @Input('snap-offset')
+  get snapOffset() { return this._snapOffset; }
+  set snapOffset(value: number) { this._snapOffset = value; }
 
   constructor(
     private el: ElementRef,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds feature to optionally allow carousel to show a portion of the previous element.

This design was made popular by the Apple App Store.

<img width="250" src="https://user-images.githubusercontent.com/3779096/39638255-a869f300-4f93-11e8-8cef-1ddd5069a274.jpg"/>

* **What is the current behavior?** (You can also link to an open issue here)

The currentIndex element aligns to the left edge of the container, regardless of whether there is a previous element.

<img width="326" alt="screen shot 2018-05-04 at 12 12 52 pm" src="https://user-images.githubusercontent.com/3779096/39638663-f1abecb6-4f94-11e8-80ab-93dbd69bbd5d.png">

* **What is the new behavior (if this is a feature change)?**

If `[snap-offset]="offset"` is set, the currentIndex element aligns `offset` pixels from the left edge of the container if there is a previous element.  This occurs on moveLeft/moveRight and on scroll with `snap-disabled="false"`.

<img width="326" alt="screen shot 2018-05-04 at 12 12 11 pm" src="https://user-images.githubusercontent.com/3779096/39638678-fede8bb4-4f94-11e8-855c-8d9a60945056.png">

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, default value leaves the functionality as-is.

* **Other information**:
