### PR TITLE
Fix ngModule not found during AOT builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2.0.0-bate.3
+- Fix build aot ngModule not found issue.
+
 #### 2.0.0-bate.2
 - Window on resizing affect scrollbar hide/show.
 - Scroll content wrapper inherits the display style from the component element.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Lightweight drag to scroll directive for Angular",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "email": "fanjin1989@gmail.com"
     }
   ],
-  "main": "lib/index.js",
+  "main": "lib",
   "scripts": {
     "prepare": "npm run ngc",
     "ng": "ng",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "es5",
-    "module": "commonjs",
+    "target": "es2015",
+    "module": "es2015",
     "moduleResolution": "node",
     "sourceMap": true,
     "lib": ["es2015", "dom"],


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed an issue where doing AOT builds in the host app gets `@ngModule` not found.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


