### PR TITLE
Notify consumers when snap animation has finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ class SampleCarousel {}
 | drag-disabled          | @Input  | Whether draging is disabled.                                                  | false |
 | snap-disabled          | @Input  | Whether snapping is disabled.                                                 | false |
 | snap-offset            | @Input  | Pixels of previous element to show on snap or moving left and right.          |   0   |
+| snap-duration          | @Input  | Duration of snap animation in milliseconds.                                   |  500  |
 | reachesLeftBound       | @Output | Whether reaching the left carousel bound.                                     |  n/a  |
 | reachesRightBound      | @Output | Whether reaching the right carousel bound.                                    |  n/a  |
+| snapAnimationFinished  | @Output | The snap animation for the new selection has finished.                        |  n/a  |
 
 ___
 

--- a/demo/app/home/home.component.html
+++ b/demo/app/home/home.component.html
@@ -6,6 +6,7 @@
       scrollbar-hidden="true"
       (reachesLeftBound)="leftBoundStat($event)"
       (reachesRightBound)="rightBoundStat($event)"
+      (snapAnimationFinished)="onSnapAnimationFinished()"
       #nav
       >
       <img drag-scroll-item *ngFor="let image of imagelist" [src]="'assets/img/' + image" (click)="clickItem(image)"/>

--- a/demo/app/home/home.component.ts
+++ b/demo/app/home/home.component.ts
@@ -50,7 +50,7 @@ export class HomeComponent implements OnInit {
   }
 
   clickItem(item) {
-    console.log('itme clicked');
+    console.log('item clicked');
   }
 
   remove() {
@@ -85,6 +85,10 @@ export class HomeComponent implements OnInit {
 
   rightBoundStat(reachesRightBound: boolean) {
     this.rightNavDisabled = reachesRightBound;
+  }
+
+  onSnapAnimationFinished() {
+    console.log("snap animation finished");
   }
 
 }

--- a/demo/app/home/home.component.ts
+++ b/demo/app/home/home.component.ts
@@ -88,7 +88,7 @@ export class HomeComponent implements OnInit {
   }
 
   onSnapAnimationFinished() {
-    console.log("snap animation finished");
+    console.log('snap animation finished');
   }
 
 }

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -345,7 +345,7 @@ describe('DragScrollComponent', () => {
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
-                 </drag-scroll>`                 
+                 </drag-scroll>`
       }
     });
     TestBed.compileComponents().then(() => {
@@ -355,7 +355,7 @@ describe('DragScrollComponent', () => {
       spyOn(fixture.componentInstance.ds.snapAnimationFinished, 'emit');
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
-      document.dispatchEvent(new MouseEvent('mouseup'));      
+      document.dispatchEvent(new MouseEvent('mouseup'));
       fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.snapAnimationFinished.emit).toHaveBeenCalledWith(2));
     });
   }));
@@ -368,7 +368,7 @@ describe('DragScrollComponent', () => {
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
                    <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
-                 </drag-scroll>`                 
+                 </drag-scroll>`
       }
     });
     TestBed.compileComponents().then(() => {
@@ -378,7 +378,7 @@ describe('DragScrollComponent', () => {
       spyOn(fixture.componentInstance.ds.snapAnimationFinished, 'emit');
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
-      document.dispatchEvent(new MouseEvent('mouseup'));      
+      document.dispatchEvent(new MouseEvent('mouseup'));
       fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.snapAnimationFinished.emit).toHaveBeenCalledTimes(0));
     });
   }));

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -336,5 +336,51 @@ describe('DragScrollComponent', () => {
       expect(fixture.componentInstance.elementClicked).toBeFalsy();
     });
   });
+
+  it('should trigger snapAnimationFinished event with currentIndex when snap is enabled', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll style="width: 100px; height: 50px;" #nav>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                 </drag-scroll>`                 
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      spyOn(fixture.componentInstance.ds.snapAnimationFinished, 'emit');
+      compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
+      document.dispatchEvent(new MouseEvent('mouseup'));      
+      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.snapAnimationFinished.emit).toHaveBeenCalledWith(2));
+    });
+  }));
+
+  it('should not trigger snapAnimationFinished event when snap is disabled', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll snap-disabled="true" style="width: 100px; height: 50px;" #nav>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                 </drag-scroll>`                 
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      const compiled = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      spyOn(fixture.componentInstance.ds.snapAnimationFinished, 'emit');
+      compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
+      document.dispatchEvent(new MouseEvent('mouseup'));      
+      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.snapAnimationFinished.emit).toHaveBeenCalledTimes(0));
+    });
+  }));
 });
 


### PR DESCRIPTION
+ feat: event is emitted when snap animation finishes
+ feat: snap animation duration can be set by input binding

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature, docs update


* **What is the current behavior?** (You can also link to an open issue here)
1) It is not possible to know whether the snap animation has already finished. Thus implementing an action after the snap animation has finished can only be done by a workaround, e.g. looking into the source code for the duration and using setTimeOut().
2) The duration of the snap animation is fixed (500ms).

* **What is the new behavior (if this is a feature change)?**
1) When the snap animation finsihes, an event is emitted to notify interested consumers. 
2) The duration for the snap animation can be set by an input binding.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
