### PR TITLE
Added EventEmitter for the indexChanged event

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ class SampleCarousel {}
 | reachesLeftBound       | @Output | Whether reaching the left carousel bound.                                     |  n/a  |
 | reachesRightBound      | @Output | Whether reaching the right carousel bound.                                    |  n/a  |
 | snapAnimationFinished  | @Output | The snap animation for the new selection has finished.                        |  n/a  |
+| indexChanged           | @Output | Executes when the current index of the carousel changes.                      |  n/a  |
 
 ___
 

--- a/demo/app/app.module.ts
+++ b/demo/app/app.module.ts
@@ -7,7 +7,8 @@ import {
   MatIconModule,
   MatSlideToggleModule,
   MatToolbarModule,
-  MatButtonModule
+  MatButtonModule,
+  MatBadgeModule,
 } from '@angular/material';
 
 import { AppComponent } from './app.component';
@@ -40,6 +41,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
     MatSlideToggleModule,
     MatToolbarModule,
     MatButtonModule,
+    MatBadgeModule,
     FlexLayoutModule
   ],
   providers: [

--- a/demo/app/home/home.component.html
+++ b/demo/app/home/home.component.html
@@ -126,6 +126,15 @@
           <td class="docs-api-property-description"> Whether reaching the right carousel bound. </td>
           <td class="docs-api-property-description">n/a</td>
         </tr>
+        <tr class="docs-api-properties-row">
+          <td class="docs-api-properties-name-cell">
+            <div class="docs-api-input-marker"> @Output()</div>
+            <p class="docs-api-property-name"> indexChanged </p>
+            <code class="docs-api-property-type"></code>
+          </td>
+          <td class="docs-api-property-description"> Executes when the current index of the carousel changes. </td>
+          <td class="docs-api-property-description">n/a</td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/demo/app/home/home.component.html
+++ b/demo/app/home/home.component.html
@@ -1,9 +1,10 @@
 <div class="content">
   <p class="title">DRAG AND SCROLL!</p>
-  <div class="demo-border">
+  <div class="demo-border" [matBadge]="index">
     <drag-scroll class="demo-one"
       drag-scroll-y-disabled="true"
       scrollbar-hidden="true"
+      (indexChanged)="index = $event"
       (reachesLeftBound)="leftBoundStat($event)"
       (reachesRightBound)="rightBoundStat($event)"
       (snapAnimationFinished)="onSnapAnimationFinished()"

--- a/demo/app/home/home.component.ts
+++ b/demo/app/home/home.component.ts
@@ -30,6 +30,7 @@ export class HomeComponent implements OnInit {
   ];
   leftNavDisabled = false;
   rightNavDisabled = false;
+  index = 0;
 
   @ViewChild('nav', {read: DragScrollComponent}) ds: DragScrollComponent;
 

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -40,6 +40,8 @@ import { DragScrollItemDirective } from './ngx-drag-scroll-item';
     `]
 })
 export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges, AfterViewChecked {
+  private _index = 0;
+
   private _scrollbarHidden = false;
 
   private _disabled = false;
@@ -103,13 +105,21 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
 
   scrollbarWidth: string | null = null;
 
-  currIndex = 0;
+  get currIndex() {return this._index; }
+  set currIndex(value) {
+    if (value !== this._index) {
+      this._index = value;
+      this.indexChanged.emit(value);
+    }
+  }
 
   isAnimating = false;
 
   scrollReachesRightEnd = false;
 
   prevChildrenLength = 0;
+
+  @Output() indexChanged = new EventEmitter<number>();
 
   @Output() reachesLeftBound = new EventEmitter<boolean>();
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`
 **NOTE**: There are 3 tests failing that were failing before any of my changes. I verified this by running the tests on the current develop branch

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR is for a feature requests to fire an event when the current index changes.


* **What is the current behavior?** (You can also link to an open issue here)
The current behavior is that you can access the currIndex property by referencing the @Child component, however, there is no way to bind or listen for the index changing.

* **What is the new behavior (if this is a feature change)?**
This feature allows developers to subscribe to the (indexChanged) event and get updates on the current idnex when it changes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
There should be no breaking change. The main change was by splitting the currIndex property into a seperate getter/setter and emitting an event when the value changes.

* **Other information**:
I specifically am checking if the currIndex changes before emitting the event to reduce unnecessary firing of the event 