### PR TITLE
Move left/right does not need to wait for the animation to finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 2.0.1
+- Resolve right click and left click not working (#174)
+
 #### 2.0.0-bate.7
 - Resolve method index changed and move right does not work (#173).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.1",
   "description": "Lightweight drag to scroll directive for Angular",
   "contributors": [
     {

--- a/tslint.json
+++ b/tslint.json
@@ -114,7 +114,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Move left/right does not need to wait for the animation to finish


* **What is the current behavior?** (You can also link to an open issue here)
Move left/right does not work while snap is in animation.

* **What is the new behavior (if this is a feature change)?**
Move left/right does not need to wait for the animation to finish



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
