### PR TITLE
feat: bind global handlers (mouseup, mousemove) on mousedown

### DIFF
--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -469,7 +469,9 @@ describe('DragScrollComponent', () => {
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
       document.dispatchEvent(new MouseEvent('mouseup'));
-      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.onMouseMove).toHaveBeenCalledTimes(1));
+      compiled.componentInstance.snapAnimationFinished.subscribe(() => {
+        expect(fixture.componentInstance.ds.onMouseMove).toHaveBeenCalledTimes(1);
+      });
     });
   }) );
 });

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -245,7 +245,7 @@ describe('DragScrollComponent', () => {
       document.dispatchEvent(new MouseEvent('mouseup'));
       // compiled.componentInstance.locateCurrentIndex(true);
 
-      fixture.whenRenderingDone().then(() => expect(compiled.nativeElement.scrollLeft).toBe(50));
+      compiled.componentInstance.snapAnimationFinished.subscribe(() => expect(compiled.nativeElement.scrollLeft).toBe(50));
     });
   }));
 
@@ -266,7 +266,7 @@ describe('DragScrollComponent', () => {
       document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -45}));
       document.dispatchEvent(new MouseEvent('mouseup'));
 
-      fixture.whenRenderingDone().then(() => expect(compiled.nativeElement.scrollLeft).toBe(40));
+      compiled.componentInstance.snapAnimationFinished.subscribe(() => expect(compiled.nativeElement.scrollLeft).toBe(40));
     });
   }));
 
@@ -363,11 +363,11 @@ describe('DragScrollComponent', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
       const compiled = fixture.debugElement.query(By.css('.drag-scroll-content'));
-      spyOn(fixture.componentInstance.ds.snapAnimationFinished, 'emit');
       compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
       document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
       document.dispatchEvent(new MouseEvent('mouseup'));
-      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.snapAnimationFinished.emit).toHaveBeenCalledWith(2));
+
+      compiled.componentInstance.snapAnimationFinished.subscribe((result) => expect(result).toBe(2));
     });
   }));
 
@@ -424,5 +424,52 @@ describe('DragScrollComponent', () => {
       expect(fixture.componentInstance.ds.indexChanged.emit).toHaveBeenCalledTimes(3);
     });
   }));
-});
 
+  it('should not listen to mousemove when mousedown is not triggered', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll style="width: 100px; height: 50px;" #nav>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                 </drag-scroll>`
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+
+      const compiled = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      spyOn(fixture.componentInstance.ds, 'onMouseMove');
+
+      document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -45}));
+      document.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, clientX: -45}));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -20  }));
+      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.onMouseMove).toHaveBeenCalledTimes(0));
+    });
+  }) );
+
+  it('should listen to mousemove when mousedown is triggered', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll style="width: 100px; height: 50px;" #nav>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                 </drag-scroll>`
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+
+      const compiled = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      spyOn(fixture.componentInstance.ds, 'onMouseMove');
+
+      compiled.triggerEventHandler('mousedown', new MouseEvent('mousedown'));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: -101  }));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      fixture.whenRenderingDone().then(() => expect(fixture.componentInstance.ds.onMouseMove).toHaveBeenCalledTimes(1));
+    });
+  }) );
+});

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -272,7 +272,6 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
     this.downX = event.clientX;
     this.downY = event.clientY;
 
-
     clearTimeout(this.scrollToTimer as number);
   }
 
@@ -291,7 +290,6 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseUpHandler(event: MouseEvent) {
-
     if (this.isPressed) {
       this.isPressed = false;
       if (!this.snapDisabled) {

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -56,9 +56,9 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
 
   private _snapDuration = 500;
 
-  private _onMouseMoveHandler: any;
+  private _onMouseMoveListener: any;
 
-  private _onMouseUpHandler: any;
+  private _onMouseUpListener: any;
 
   /**
    * Is the user currently pressing the element
@@ -362,22 +362,22 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   private _startGlobalListening() {
-    if (!this._onMouseMoveHandler) {
-      this._onMouseMoveHandler = this._renderer.listen('document', 'mousemove', this.onMouseMoveHandler.bind(this));
+    if (!this._onMouseMoveListener) {
+      this._onMouseMoveListener = this._renderer.listen('document', 'mousemove', this.onMouseMoveHandler.bind(this));
     }
 
-    if (!this._onMouseUpHandler) {
-      this._onMouseUpHandler = this._renderer.listen('document', 'mouseup', this.onMouseUpHandler.bind(this));
+    if (!this._onMouseUpListener) {
+      this._onMouseUpListener = this._renderer.listen('document', 'mouseup', this.onMouseUpHandler.bind(this));
     }
   }
 
   private _stopGlobalListening() {
-    if (this._onMouseMoveHandler) {
-      this._onMouseMoveHandler = this._onMouseMoveHandler();
+    if (this._onMouseMoveListener) {
+      this._onMouseMoveListener = this._onMouseMoveListener();
     }
 
-    if (this._onMouseUpHandler) {
-      this._onMouseUpHandler = this._onMouseUpHandler();
+    if (this._onMouseUpListener) {
+      this._onMouseUpListener = this._onMouseUpListener();
     }
   }
 

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -245,6 +245,10 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseMoveHandler(event: MouseEvent) {
+    this.onMouseMove(event);
+  }
+
+  onMouseMove(event: MouseEvent) {
     if (this.isPressed && !this.disabled) {
       // // Drag X
       if (!this.xDisabled && !this.dragDisabled) {
@@ -263,11 +267,11 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseDownHandler(event: MouseEvent) {
+    this._startGlobalListening();
     this.isPressed = true;
     this.downX = event.clientX;
     this.downY = event.clientY;
 
-    this._startGlobalListening();
 
     clearTimeout(this.scrollToTimer as number);
   }
@@ -287,7 +291,6 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseUpHandler(event: MouseEvent) {
-    this._stopGlobalListening();
 
     if (this.isPressed) {
       this.isPressed = false;
@@ -296,6 +299,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
       } else {
         this.locateCurrentIndex();
       }
+      this._stopGlobalListening();
     }
   }
 

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -56,6 +56,10 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
 
   private _snapDuration = 500;
 
+  private _onMouseMoveHandler: any;
+
+  private _onMouseUpHandler: any;
+
   /**
    * Is the user currently pressing the element
    */
@@ -215,8 +219,6 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
     this._renderer.listen(this._contentRef.nativeElement, 'mousedown', this.onMouseDownHandler.bind(this));
     this._renderer.listen(this._contentRef.nativeElement, 'touchstart', this.onMouseDownHandler.bind(this));
     this._renderer.listen(this._contentRef.nativeElement, 'scroll', this.onScrollHandler.bind(this));
-    this._renderer.listen('document', 'mousemove', this.onMouseMoveHandler.bind(this));
-    this._renderer.listen('document', 'mouseup', this.onMouseUpHandler.bind(this));
     this._renderer.listen(this._contentRef.nativeElement, 'touchend', this.onMouseUpHandler.bind(this));
 
     // prevent Firefox from dragging images
@@ -264,6 +266,9 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
     this.isPressed = true;
     this.downX = event.clientX;
     this.downY = event.clientY;
+
+    this._startGlobalListening();
+
     clearTimeout(this.scrollToTimer as number);
   }
 
@@ -282,6 +287,8 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseUpHandler(event: MouseEvent) {
+    this._stopGlobalListening();
+
     if (this.isPressed) {
       this.isPressed = false;
       if (!this.snapDisabled) {
@@ -352,6 +359,26 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
         this.reachesRightBound.emit(false);
       }
     }, 0);
+  }
+
+  private _startGlobalListening() {
+    if (!this._onMouseMoveHandler) {
+      this._onMouseMoveHandler = this._renderer.listen('document', 'mousemove', this.onMouseMoveHandler.bind(this));
+    }
+
+    if (!this._onMouseUpHandler) {
+      this._onMouseUpHandler = this._renderer.listen('document', 'mouseup', this.onMouseUpHandler.bind(this));
+    }
+  }
+
+  private _stopGlobalListening() {
+    if (this._onMouseMoveHandler) {
+      this._onMouseMoveHandler = this._onMouseMoveHandler();
+    }
+
+    if (this._onMouseUpHandler) {
+      this._onMouseUpHandler = this._onMouseUpHandler();
+    }
   }
 
   private disableScroll(axis: string): void {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix / feat.


* **What is the current behavior?** (You can also link to an open issue here)
Unnecessary listening to mousemove events on the page.


* **What is the new behavior (if this is a feature change)?**
Bind mousemove events only when mousedown is triggered for that component. Allowing multiple components to be used on the same page without throttling.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not breaking changes, only a behavior fix.


* **Other information**:
Some tests that uses `fixture.whenRenderingDone()` are executing the check before the events are triggered returning a false response.

For instance the following test, should not pass if the mousemove events are bound in ngAfterViewInit method, but it is passing anyway:

`
  it('should not listen to mousemove when mousedown is not triggered', async(() => {...});
`
