### PR TITLE
fix: refresh wrapper's dimensions after window resize when scrollbar is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+#### 7.1.1
+- refresh wrapper's dimensions after window resize when scrollbar is hidden
 #### 7.1.0
 - add index bound (#202)
 - drag-scroll-disabled alternative for children (#144)

--- a/demo/app/home/home.component.css
+++ b/demo/app/home/home.component.css
@@ -12,6 +12,17 @@
   width: 260px;
 }
 
+@media (max-width: 1000px) {
+  .demo-one {
+    height: 200px;
+  }
+
+  .demo-one img {
+    width: 200px;
+    height: 200px;
+  }
+}
+
 .demo-two {
   height: 500px;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Lightweight drag to scroll library for Angular",
   "contributors": [
     {

--- a/src/ngx-drag-scroll.spec.ts
+++ b/src/ngx-drag-scroll.spec.ts
@@ -497,4 +497,32 @@ describe('DragScrollComponent', () => {
       });
     });
   }));
+
+  it('should update wrapper\'s height after window resize if scrollbar is hidden', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll scrollbar-hidden="true" #nav>
+                   <div drag-scroll-item class="item" style="width: 50px; height: 50px;"></div>
+                 </drag-scroll>`,
+        styles: [`
+          drag-scroll {
+            width: 100px;
+            height: 100px;
+          }
+        `]
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const dragScroll = fixture.nativeElement.querySelector('drag-scroll');
+      const dragScrollWrapper = fixture.nativeElement.querySelector('.drag-scroll-wrapper');
+
+      dragScroll.style.height = '50px';
+      window.dispatchEvent(new Event('resize'));
+
+      expect(dragScrollWrapper.offsetHeight).toBe(50);
+    });
+  }));
 });

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -12,7 +12,8 @@ import {
   ContentChildren,
   AfterViewChecked,
   QueryList,
-  Inject
+  Inject,
+  HostListener
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
@@ -431,9 +432,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
       this._renderer.setAttribute(this.wrapper, 'class', 'drag-scroll-wrapper');
       this._renderer.addClass(this.wrapper, 'drag-scroll-container');
 
-      this._renderer.setStyle(this.wrapper, 'width', '100%');
-      this._renderer.setStyle(this.wrapper, 'height', this._elementRef.nativeElement.style.height
-        || this._elementRef.nativeElement.offsetHeight + 'px');
+      this.refreshWrapperDimensions();
 
       this._renderer.setStyle(this.wrapper, 'overflow', 'hidden');
 
@@ -518,6 +517,14 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
      * setting default width to 20;
      */
     return widthNoScroll - widthWithScroll || 20;
+  }
+
+  private refreshWrapperDimensions() {
+    if (this.wrapper) {
+      this._renderer.setStyle(this.wrapper, 'width', '100%');
+      this._renderer.setStyle(this.wrapper, 'height', this._elementRef.nativeElement.style.height
+        || this._elementRef.nativeElement.offsetHeight + 'px');
+    }
   }
 
   /*
@@ -676,5 +683,10 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   private isScrollReachesRightEnd(): boolean {
     const scrollLeftPos = this._contentRef.nativeElement.scrollLeft + this._contentRef.nativeElement.offsetWidth;
     return scrollLeftPos >= this._contentRef.nativeElement.scrollWidth;
+  }
+
+  @HostListener('window:resize')
+  private onWindowResize() {
+    this.refreshWrapperDimensions();
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [/] The commit message follows our guidelines
- [/] Tests for the changes have been added (for bug fixes / features)
- [/] Docs have been added / updated (for bug fixes / features)
- [/] Unit tests are passing `ng test`
- [/] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When drag-scroll's height changes after component has been initialized (eg. because of media-queries) and scrollbar is hidden, .drag-scroll-wrapper's height does not update along with it.


* **What is the new behavior (if this is a feature change)?**
.drag-scroll-wrapper's dimensions are recalculated after each window resize event.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. User's will notice no impact at all.


* **Other information**:
