### PR TITLE
toChildrenLocation doesn't go to the right location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+#### 7.2.9
+- fix: moveTo doesn't include the margin of the last item when the scroll bars are hidden.
 #### 7.1.6
 - fix: cannot compile with aot (#220)
 #### 7.1.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "7.1.6",
+  "version": "7.2.9",
   "description": "Lightweight drag to scroll library for Angular",
   "contributors": [
     {

--- a/src/ngx-drag-scroll.ts
+++ b/src/ngx-drag-scroll.ts
@@ -666,7 +666,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   private toChildrenLocation(): number {
-    let to = 0;
+    let to = this.scrollbarHidden ? this.getScrollbarWidth() : 0;
     for (let i = 0; i < this.currIndex; i++) {
       to += this._children['_results'][i]._elementRef.nativeElement.clientWidth;
     }


### PR DESCRIPTION
Fix an issue where the toChildrenLocation doesn't go to the right location when the last item has a margin to the right*.

*We add margin-right of the width of the scroll bar to the last item in the carousel when the scroll bar is hidden.