### PR TITLE
fix: forward snap should not happen when the scroll left is 0

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -28,6 +28,7 @@ import { DragScrollItemDirective } from './ngx-drag-scroll-item';
   `,
   styles: [`
     :host {
+      overflow: hidden;
       display: block;
     }
     .drag-scroll-content {
@@ -644,7 +645,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
           if (snap) {
             this.scrollTo(this._contentRef.nativeElement, childrenWidth, this.snapDuration);
           }
-        } else {
+        } else if (this._contentRef.nativeElement.scrollLeft !== 0) {
           // forward scrolling
           if (!this.isAnimating) {
             this.currIndex = idx + 1;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Do not forward snap when the item is against the left of the border(scroll left 0).


