### PR TITLE
fix: prevent error in case of empty content or no drag-scroll-item is used

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
@@ -60,6 +60,37 @@ describe('DragScrollComponent', () => {
     });
   });
 
+  it('should not throw error in case of empty content', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll>
+                 </drag-scroll>`
+      }
+    });
+
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      expect().nothing();
+    });
+  }));
+
+  it('should not throw error in case of items without drag-scroll-item', async(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll>
+                    <div style="width: 300px; height: 300px;"></div>
+                 </drag-scroll>`
+      }
+    });
+
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      expect().nothing();
+    });
+  }));
+
   it('should drag to scroll horizontally and vertically', async(() => {
     TestBed.overrideComponent(TestComponent, {
       set: {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?**
bug fix + code improvements


* **What is the current behavior?**
Currently there is an error in case we do not use `drag-scroll-item` directive after update to latest 7 version of library - same error as in https://github.com/bfwg/ngx-drag-scroll/issues/244


* **What is the new behavior (if this is a feature change)?**
1. added a check on the existence of at least one element of type `DragScrollItemDirective` in method `adjustMarginToLastChild`
```ts
  private adjustMarginToLastChild(): void {
    if (this._children && this._children.length > 0 && this.hideScrollbar) {
     //...
    }
  }
``` 
2. removed access to private property `_results` of `QueryList`. Mostly replaced with public `length` property and `toArray()` method in case of iterations.

* **Does this PR introduce a breaking change?**
No there is no breaking change.


* **Other information**:
Close https://github.com/bfwg/ngx-drag-scroll/issues/244. 
Possibly also https://github.com/bfwg/ngx-drag-scroll/issues/229