### PR TITLE
fix: restrict drag action to ngx-drag-scroll component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,21 @@
+#### 8.0.0-beta.3
+fix: limit drag restriction of other elements to the contents of drag-scroll (#262)
 #### 8.0.0-beta.2
 fix: prevent error in case of no content or drag-scroll-item is used (#245)
 ci: update travis config to latest xenial dist and use xvfb as service (#246)
 #### 8.0.0-beta.1
 feat: update packages (#243)
 #### 7.4.3
-fix: handle first child undifined issue (#241) 
+fix: handle first child undifined issue (#241)
 #### 7.4.2
-fix: prevent click on drag end (close #154) (#230) 
+fix: prevent click on drag end (close #154) (#230)
 #### 7.4.1
 fix: forward snap should not happen when the scroll left is 0
 #### 7.4.0
-feat: add dragStart and dragEnd events (close #222) (#237) 
+feat: add dragStart and dragEnd events (close #222) (#237)
 fix: prevent scroll stuck if browser lost focus on Windows (#236)
 fix: error in the demo console log (#239)
-fix: copy artifacts on package build (#238) 
+fix: copy artifacts on package build (#238)
 #### 7.3.7
 fix: resolved a dragging bug in iOS devices
 #### 7.3.6
@@ -25,7 +27,7 @@ fix: help npm to find README.md
 #### 7.3.3
 fix: prevent scroll stuck if browser lost focus (#231)
 #### 7.3.2
-fix: issue #226 making drag-scroll work properly with touch-input 
+fix: issue #226 making drag-scroll work properly with touch-input
 #### 7.3.1
 - feat: build library as universal angular package (#224)
 #### 7.2.9
@@ -169,7 +171,7 @@ Issue #97  - Upgrade angular cli to 1.6.1 / flex-layout to 2.0.0-beta.12 and dow
 
 ### 1.6.0
 
-Issue #94 - Upgrade to Material 5 / Angular 5.1.0 
+Issue #94 - Upgrade to Material 5 / Angular 5.1.0
 
 #### 1.5.5
 

--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -253,7 +253,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
     this._onMouseDownListener = this._renderer.listen(this._contentRef.nativeElement, 'mousedown', this.onMouseDownHandler.bind(this));
     this._onScrollListener = this._renderer.listen(this._contentRef.nativeElement, 'scroll', this.onScrollHandler.bind(this));
     // prevent Firefox from dragging images
-    this._onDragStartListener = this._renderer.listen('document', 'dragstart', (e) => {
+    this._onDragStartListener = this._renderer.listen(this._contentRef.nativeElement, 'dragstart', (e) => {
       e.preventDefault();
     });
     this.checkNavStatus();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for issue #262 


* **What is the current behavior?** (You can also link to an open issue here)
When using ngx-drag-scroll, other HTML5 elements in the same page cannot be dragged.


* **What is the new behavior (if this is a feature change)?**
You can now use other HTML5 draggable elements in the same page as ngx-drag-scroll


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
I've made this suggestion some time ago but I haven't opened a PR yet. This change has fixed my issue up to now and I believe it could solve the problem for others. This is my first PR, please be nice ;)