### PR TITLE
style: safeguard wrapper height when dimensions are not yet available

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
@@ -643,6 +643,29 @@ describe('DragScrollComponent', () => {
     });
   }));
 
+  it('should set wrapper\'s height to default if pixel values aren\'t available', waitForAsync(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll scrollbar-hidden="true" #nav>
+                   <div class="drag-scroll-wrapper drag-scroll-container"></div>
+                 </drag-scroll>`,
+        styles: [`
+          drag-scroll {
+            width: 100%;
+            height: 0px;
+          }
+        `]
+      }
+    });
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const dragScrollWrapper = fixture.nativeElement.querySelector('.drag-scroll-wrapper');
+      expect(dragScrollWrapper.style.height).toBe('100%');
+    });
+  }));
+
   describe('When scrolling horizontally with mouse wheel', () => {
     let fixture: ComponentFixture<TestComponent>;
     let dragScroll: HTMLElement;

--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -591,8 +591,12 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   private refreshWrapperDimensions() {
     if (this.wrapper) {
       this._renderer.setStyle(this.wrapper, 'width', '100%');
-      this._renderer.setStyle(this.wrapper, 'height', this._elementRef.nativeElement.style.height
-        || this._elementRef.nativeElement.offsetHeight + 'px');
+      if (this._elementRef.nativeElement.style.height > 0 || this._elementRef.nativeElement.offsetHeight > 0) {
+        this._renderer.setStyle(this.wrapper, 'height', this._elementRef.nativeElement.style.height
+          || this._elementRef.nativeElement.offsetHeight + 'px');
+      } else {
+        this._renderer.setStyle(this.wrapper, 'height', '100%');
+      }
     }
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Style fix


* **What is the current behavior?** (You can also link to an open issue here)
When setting `[scrollbar-hidden]` to `true` in the template the whole slider disappears. The elements are all present in the DOM but the first direct child of `<drag-scroll>`, namely the element with the classes `drag-scroll-wrapper drag-scroll-container`, has a height of `0` and hence isn't visible.


* **What is the new behavior (if this is a feature change)?**
The element in question will apply a value of `100%` as its `height` if there aren't any pixel values from its dimensions (yet).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. There is no action required.



* **Other information**:
