### PR TITLE
fix: pointer events not propagated after window resize

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.spec.ts
@@ -820,6 +820,7 @@ describe('DragScrollComponent', () => {
         `
       }
     });
+
     TestBed.compileComponents().then(() => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
@@ -830,4 +831,47 @@ describe('DragScrollComponent', () => {
       });
     });
   });
+
+  it('should propagate pointer events after mousedown mousemove at same coordinates', waitForAsync(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll><div drag-scroll-item style="width: 300px; height: 300px;"></div></drag-scroll>`
+      }
+    });
+
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const dragScroll = fixture.debugElement.query(By.css('drag-scroll'));
+      const dragScrollContent = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      dragScrollContent.triggerEventHandler('mousedown', new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 10 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 10, clientY: 10 }));
+
+      fixture.detectChanges();
+      expect(dragScroll.styles.pointerEvents).toBe('auto');
+    });
+  }));
+
+  it('should propagate pointer events after mousedown mousemove at different coordinates', waitForAsync(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<drag-scroll><div drag-scroll-item style="width: 300px; height: 300px;"></div></drag-scroll>`
+      }
+    });
+
+    TestBed.compileComponents().then(() => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const dragScroll = fixture.debugElement.query(By.css('drag-scroll'));
+      const dragScrollContent = fixture.debugElement.query(By.css('.drag-scroll-content'));
+      dragScrollContent.triggerEventHandler('mousedown', new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 10 }));
+      document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: +5, clientY: +5 }));
+
+      fixture.detectChanges();
+      expect(dragScroll.styles.pointerEvents).toBe('none');
+    });
+  }));
+
 });

--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -289,6 +289,10 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   onMouseMove(event: MouseEvent) {
+    if (event.clientX === this.downX && event.clientY === this.downY) {
+      // Ignore 'mousemove" event triggered at the same coordinates that the last mousedown event (consequence of window resize)
+      return;
+    }
     if (this.isPressed && !this.disabled) {
       // Workaround for prevent scroll stuck if browser lost focus
       // MouseEvent.buttons not support by Safari


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
After the window is resized, frst click on an item is not propagated.
In this case, browser sends a "mouseover" between "mousedown" and "mouseup" events; all ​at the same coordinates.
The library transforms them to a "0px scroll" and disable pointer events.



* **What is the new behavior (if this is a feature change)?**
The library ignore "mouseover" event if its coordinates are the same than the previous "mousedown" ones.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**: