### PR TITLE
fix: add Angular 13 (patch and minor) to peer dependencies

### DIFF
--- a/projects/ngx-drag-scroll/package.json
+++ b/projects/ngx-drag-scroll/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-scroll",
-  "version": "12.0.0-beta.1",
+  "version": "13.0.0-beta.1",
   "description": "Lightweight drag to scroll library for Angular",
   "contributors": [
     {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bfwg/ngx-drag-scroll#readme",
   "peerDependencies": {
-    "@angular/common": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-    "@angular/core": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "@angular/common": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ~13.0.0",
+    "@angular/core": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ~13.0.0"
   }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [ ] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When upgrading the `ngx-drag-scroll` package to latest v13.0.0-beta.1 in a project that uses Angular v13, node is unable to resolve the dependency tree as the [package.json](https://github.com/bfwg/ngx-drag-scroll/blob/develop/projects/ngx-drag-scroll/package.json) does not state Angular 13 as a peer dependency.


* **What is the new behavior (if this is a feature change)?**
The package.json now states Angular 13 (both as patch `~13.0.0` and as minor updates version `^13.0.0`). The expected behaviour is to upgrade `ngx-drag-scroll` in other projects without peer dependency issue caused by it.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:
Maybe the peer dependencies should not state that many past versions. Currently the list mentions Angular versions starting at `^5.0.0` which should probably be phased out together with some more past versions.