### PR TITLE
fix: when direction:rtl style applied, move functions failed to work

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -32,6 +32,10 @@ import { DragScrollItemDirective } from './ngx-drag-scroll-item';
       overflow: hidden;
       display: block;
     }
+    .rtl-compensation {
+      direction: ltr;
+      transform: scaleX(-1);
+    }
     .drag-scroll-content {
       height: 100%;
       overflow: auto;
@@ -141,6 +145,8 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   prevChildrenLength = 0;
 
   indexBound = 0;
+
+  rtl = false;
 
   @Output() dsInitialized = new EventEmitter<void>();
 
@@ -259,6 +265,14 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
     this.checkNavStatus();
     this.dsInitialized.emit();
     this.adjustMarginToLastChild();
+
+    // after rtl compensation class is added this will reset to false so first time it's true - it sticks
+    if (!this.rtl) {
+      this.rtl = getComputedStyle(this._contentRef.nativeElement).getPropertyValue('direction') === 'rtl';
+      if (this.rtl) {
+        this._contentRef.nativeElement.classList.add('rtl-compensation')
+      }
+    }
   }
 
   ngAfterViewChecked() {
@@ -307,8 +321,13 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
       // Drag X
       if (!this.xDisabled && !this.dragDisabled) {
         const clientX = (event as MouseEvent).clientX;
-        this._contentRef.nativeElement.scrollLeft =
-          this._contentRef.nativeElement.scrollLeft - clientX + this.downX;
+        if (this.rtl) {
+          this._contentRef.nativeElement.scrollLeft =
+            this._contentRef.nativeElement.scrollLeft + clientX - this.downX;
+        } else {
+          this._contentRef.nativeElement.scrollLeft =
+            this._contentRef.nativeElement.scrollLeft - clientX + this.downX;
+        }
         this.downX = clientX;
       }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x ] Unit tests are passing `ng test`
- [x ] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - when direction:rtl style is used (Hebrew in my case) the move functions do not work.


* **What is the current behavior?** (You can also link to an open issue here)
just apply a "direction:rtl" to the style of say the demo page, and you'll see the failed functionality


* **What is the new behavior (if this is a feature change)?**
a quick fix - forcing 'direction:rtl' and flipping the UI did the trick, only thing left was a twirq in position calculation (reversing it) and it did the trick.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no.


* **Other information**:
This should have been a nicer "richer" commit, With changes to move functions according to functionality (moveLeft is actually moving right and vice versa) but hey - it's moving now. It didn't before. Also - with testing - made sure all passed, but didn't add new ones. I just figured it is NOT working today, and it IS working after this quick tiny fix, at least on "my machine", why not push it? I've seen some users requesting it, like https://github.com/bfwg/ngx-drag-scroll/issues/270 so figured why not try a PR