### PR TITLE
fix: patch to direction:rtl flipped the content. fixing logic instead

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -395,7 +395,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   moveTo(index: number) {
-    const container = this.wrapper || this.parentNode || this._contentRef.nativeElement.parentNode;
+    const container = this.wrapper || this.parentNode;
     const containerWidth = container ? container.clientWidth : 0;
     if (
       index >= 0 &&

--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -395,7 +395,7 @@ export class DragScrollComponent implements OnDestroy, AfterViewInit, OnChanges,
   }
 
   moveTo(index: number) {
-    const container = this.wrapper || this.parentNode;
+    const container = this.wrapper || this.parentNode || this._contentRef.nativeElement.parentNode;
     const containerWidth = container ? container.clientWidth : 0;
     if (
       index >= 0 &&


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
after my last commit to support direction:rtl, Move functions worked but the content got flipped. See I wanted to keep the existing "math" logic and just trick the browser... but the content got flipped. so I removed the flipping code and instead changed the scrollLeft calcs to support negatives (it was just 3 tiny places. rest of commit is actually removing of the old fix).


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
