### PR TITLE
fix: guard getComputedStyle for SSR

### DIFF
--- a/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
+++ b/projects/ngx-drag-scroll/src/lib/ngx-drag-scroll.component.ts
@@ -270,9 +270,11 @@ export class DragScrollComponent
     this.adjustMarginToLastChild();
 
     this.rtl =
-      getComputedStyle(this._contentRef.nativeElement).getPropertyValue(
-        'direction'
-      ) === 'rtl';
+      typeof window !== 'undefined'
+        ? window
+            .getComputedStyle(this._contentRef.nativeElement)
+            .getPropertyValue('direction') === 'rtl'
+        : false;
   }
 
   ngAfterViewChecked() {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Unit tests are passing `ng test`
- [x] Lint tests are passing `ng lint`

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When using `ngx-drag-scroll` with Angular Universal / SSR, the component can throw `ReferenceError: getComputedStyle is not defined`.

The first `getComputedStyle` usage in `ngAfterViewInit` is already guarded with a browser check, but the RTL direction check still calls `getComputedStyle` directly.

Fixes #314

* **What is the new behavior (if this is a feature change)?**

The RTL direction check now only runs in the browser.

On the server, `rtl` defaults to `false`, so SSR rendering no longer fails because of the missing browser API. Browser behavior remains unchanged.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

`ng lint` passes.

`ng test` currently fails locally because some existing scrollbar-related specs expect a hardcoded scrollbar width of `15px`, while Chrome 150 on macOS computes `20px`. Those failures appear unrelated to this SSR guard change.
